### PR TITLE
Create lib path if it doesn't exist

### DIFF
--- a/Sources/MadMachine/MadMachine.swift
+++ b/Sources/MadMachine/MadMachine.swift
@@ -77,15 +77,17 @@ public struct MadMachine {
 
     /// note: this could be a throwing init...?
     public init(toolchainLocation: String = MadMachine.Paths.toolchain.location,
-                libLocation: String = MadMachine.Paths.lib.location)
+                libLocation: String = MadMachine.Paths.lib.location) throws
     {
         let toolchainPath = Path(toolchainLocation)
         if !toolchainPath.exists || !toolchainPath.isDirectory {
             fatalError("Can not find toolchain path at `\(toolchainLocation)`")
         }
         let libPath = Path(libLocation)
-        if !libPath.exists || !libPath.isDirectory {
-            fatalError("Can not find lib path at `\(libLocation)`")
+        if !libPath.exists {
+            try libPath.create()
+        } else if !libPath.isDirectory {
+            fatalError("Expected lib path to be a directory at `\(libLocation)`")
         }
         self.toolchainLocation = toolchainLocation
         self.libLocation = libLocation

--- a/Sources/MadMachineCli/Commands/BuildCommand.swift
+++ b/Sources/MadMachineCli/Commands/BuildCommand.swift
@@ -93,7 +93,7 @@ final class BuildCommand: Command {
             p = customImportSearchPaths.split(separator: ",").map(String.init).map(\.resolvedPath)
         }
                 
-        let mm = MadMachine(toolchainLocation: t, libLocation: l)
+        let mm = try MadMachine(toolchainLocation: t, libLocation: l)
 
         if signature.verbose {
             let info = """


### PR DESCRIPTION
When setting up the CLI I've encountered an exception when trying to build a library without manually creating the folder `~/.MadMachine/lib` as this wasn't pre-created.

With this PR the directory will be tried to created prior to accessing it.